### PR TITLE
add Dell LTO5-140 (IBM model) to supported devices

### DIFF
--- a/ltfs/src/tape_drivers/windows/ltotape/ltotape_supdevs.h
+++ b/ltfs/src/tape_drivers/windows/ltotape/ltotape_supdevs.h
@@ -28,6 +28,10 @@
 *************************************************************************************
 */
 
+/*
+ * 2017-03-08 add ULTRIUM-HH5
+ */
+
 #ifndef __ltotape_supdevs_h
 #define __ltotape_supdevs_h
 
@@ -35,17 +39,18 @@
  * Array of device types supported by this back end:
  */
 const supported_device_type supported_devices[] = {
-   { "Ultrium 5-SCSI  ", drivefamily_lto,     "HP LTO5",			drive_lto5  	},
-   { "Ultrium 6-SCSI  ", drivefamily_lto,     "HP LTO6",			drive_lto6  	},
-   { "Ultrium 7-SCSI  ", drivefamily_lto,     "HP LTO7",			drive_lto7  	},
-   { "ULTRIUM 5       ", drivefamily_lto,     "Quantum LTO5",		drive_lto5  	},
-   { "ULTRIUM 6       ", drivefamily_lto,     "Quantum LTO6",      	drive_lto6		},
-   { "ULTRIUM 7       ", drivefamily_lto,     "Quantum LTO7",      	drive_lto7		},
-   { "LTO-5 HH        ", drivefamily_lto,     "TANDBERG DATA LTO5", drive_lto5 		},
-   { "LTO-6 HH        ", drivefamily_lto,     "TANDBERG DATA LTO6",	drive_lto6		},
-   { "DAT320          ", drivefamily_dat,     "HP DAT320",			drive_dat   	},
-   { "DAT160          ", drivefamily_dat,     "HP DAT160",			drive_dat   	},
-   { (const char*)NULL,  drivefamily_unknown, "Unknown",			drive_unknown	}
+   { "Ultrium 5-SCSI  ", drivefamily_lto,     "HP LTO5",            drive_lto5    },
+   { "Ultrium 6-SCSI  ", drivefamily_lto,     "HP LTO6",            drive_lto6    },
+   { "Ultrium 7-SCSI  ", drivefamily_lto,     "HP LTO7",            drive_lto7    },
+   { "ULTRIUM 5       ", drivefamily_lto,     "Quantum LTO5",       drive_lto5    },
+   { "ULTRIUM 6       ", drivefamily_lto,     "Quantum LTO6",       drive_lto6    },
+   { "ULTRIUM 7       ", drivefamily_lto,     "Quantum LTO7",       drive_lto7    },
+   { "LTO-5 HH        ", drivefamily_lto,     "TANDBERG DATA LTO5", drive_lto5    },
+   { "LTO-6 HH        ", drivefamily_lto,     "TANDBERG DATA LTO6", drive_lto6    },
+   { "ULTRIUM-HH5     ", drivefamily_lto,     "DELL LTO5-140",      drive_lto5    },
+   { "DAT320          ", drivefamily_dat,     "HP DAT320",          drive_dat     },
+   { "DAT160          ", drivefamily_dat,     "HP DAT160",          drive_dat     },
+   { (const char*)NULL,  drivefamily_unknown, "Unknown",            drive_unknown }
 };
 
 #endif // __ltotape_diag_h


### PR DESCRIPTION
- this is the Windows support 
- macOS support already done by https://github.com/amiaopensource/ltfs/pull/3
- Linux uses the macOS `ltotape_supdevs.h`