### PR TITLE
add support for drives on Windows

### DIFF
--- a/ltfs/src/tape_drivers/windows/ltotape/ltotape_supdevs.h
+++ b/ltfs/src/tape_drivers/windows/ltotape/ltotape_supdevs.h
@@ -30,6 +30,7 @@
 
 /*
  * 2017-03-08 add ULTRIUM-HH5
+ * 2017-03-12 add LTO-7 HH, ULTRIUM-HH6 and ULTRIUM-HH7
  */
 
 #ifndef __ltotape_supdevs_h
@@ -47,7 +48,10 @@ const supported_device_type supported_devices[] = {
    { "ULTRIUM 7       ", drivefamily_lto,     "Quantum LTO7",       drive_lto7    },
    { "LTO-5 HH        ", drivefamily_lto,     "TANDBERG DATA LTO5", drive_lto5    },
    { "LTO-6 HH        ", drivefamily_lto,     "TANDBERG DATA LTO6", drive_lto6    },
+   { "LTO-7 HH        ", drivefamily_lto,     "TANDBERG DATA LTO7", drive_lto7    },
    { "ULTRIUM-HH5     ", drivefamily_lto,     "DELL LTO5-140",      drive_lto5    },
+   { "ULTRIUM-HH6     ", drivefamily_lto,     "DELL LTO6",          drive_lto6    },
+   { "ULTRIUM-HH7     ", drivefamily_lto,     "DELL LTO7",          drive_lto7    },
    { "DAT320          ", drivefamily_dat,     "HP DAT320",          drive_dat     },
    { "DAT160          ", drivefamily_dat,     "HP DAT160",          drive_dat     },
    { (const char*)NULL,  drivefamily_unknown, "Unknown",            drive_unknown }


### PR DESCRIPTION
Add support for the following drives:
- `LTO-7 HH` (Tandberg)
- `ULTRIUM-HH6` (Dell aka IBM drive)
- `ULTRIUM-HH7` (Dell aka IBM drive)

on Windows. For macOS see the [specific PR](https://github.com/amiaopensource/ltfs/pull/7) (which is used also by Linux).