### PR TITLE
add support for drives on macOS (and Linux)

### DIFF
--- a/ltfs/src/tape_drivers/osx/ltotape/ltotape_supdevs.h
+++ b/ltfs/src/tape_drivers/osx/ltotape/ltotape_supdevs.h
@@ -30,6 +30,7 @@
 
 /*
  * 2017-03-08 add ULTRIUM-HH5
+ * 2017-03-12 add LTO-7 HH, ULTRIUM-HH6 and ULTRIUM-HH7
  */
 
 #ifndef __ltotape_supdevs_h
@@ -39,18 +40,21 @@
  * Array of device types supported by this back end:
  */
 const supported_device_type supported_devices[] = {
-   { "Ultrium 5-SCSI  ", drivefamily_lto,     "HP LTO5",			drive_lto5  	},
-   { "Ultrium 6-SCSI  ", drivefamily_lto,     "HP LTO6",			drive_lto6  	},
-   { "Ultrium 7-SCSI  ", drivefamily_lto,     "HP LTO7",			drive_lto7  	},
-   { "ULTRIUM 5       ", drivefamily_lto,     "Quantum LTO5",		drive_lto5  	},
-   { "ULTRIUM 6       ", drivefamily_lto,     "Quantum LTO6",      	drive_lto6		},
-   { "ULTRIUM 7       ", drivefamily_lto,     "Quantum LTO7",      	drive_lto7		},
-   { "LTO-5 HH        ", drivefamily_lto,     "TANDBERG DATA LTO5", drive_lto5 		},
-   { "LTO-6 HH        ", drivefamily_lto,     "TANDBERG DATA LTO6",	drive_lto6		},
-   { "ULTRIUM-HH5     ", drivefamily_lto,     "DELL LTO5-140",      drive_lto5		},
-   { "DAT320          ", drivefamily_dat,     "HP DAT320",			drive_dat   	},
-   { "DAT160          ", drivefamily_dat,     "HP DAT160",			drive_dat   	},
-   { (const char*)NULL,  drivefamily_unknown, "Unknown",			drive_unknown	}
+   { "Ultrium 5-SCSI  ", drivefamily_lto,     "HP LTO5",            drive_lto5    },
+   { "Ultrium 6-SCSI  ", drivefamily_lto,     "HP LTO6",            drive_lto6    },
+   { "Ultrium 7-SCSI  ", drivefamily_lto,     "HP LTO7",            drive_lto7    },
+   { "ULTRIUM 5       ", drivefamily_lto,     "Quantum LTO5",       drive_lto5    },
+   { "ULTRIUM 6       ", drivefamily_lto,     "Quantum LTO6",       drive_lto6    },
+   { "ULTRIUM 7       ", drivefamily_lto,     "Quantum LTO7",       drive_lto7    },
+   { "LTO-5 HH        ", drivefamily_lto,     "TANDBERG DATA LTO5", drive_lto5    },
+   { "LTO-6 HH        ", drivefamily_lto,     "TANDBERG DATA LTO6", drive_lto6    },
+   { "LTO-7 HH        ", drivefamily_lto,     "TANDBERG DATA LTO7", drive_lto7    },
+   { "ULTRIUM-HH5     ", drivefamily_lto,     "DELL LTO5-140",      drive_lto5    },
+   { "ULTRIUM-HH6     ", drivefamily_lto,     "DELL LTO6",          drive_lto6    },
+   { "ULTRIUM-HH7     ", drivefamily_lto,     "DELL LTO7",          drive_lto7    },
+   { "DAT320          ", drivefamily_dat,     "HP DAT320",          drive_dat     },
+   { "DAT160          ", drivefamily_dat,     "HP DAT160",          drive_dat     },
+   { (const char*)NULL,  drivefamily_unknown, "Unknown",            drive_unknown }
 };
 
 #endif // __ltotape_diag_h


### PR DESCRIPTION
Add support for the following drives:
- `LTO-7 HH` (Tandberg)
- `ULTRIUM-HH6` (Dell aka IBM drive)
- `ULTRIUM-HH7` (Dell aka IBM drive)

on macOS (which is used also by Linux). For Windows see the [specific PR](https://github.com/amiaopensource/ltfs/pull/6).